### PR TITLE
Clean up third-party package notices(imagedecoder)

### DIFF
--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -1,0 +1,166 @@
+THIRD-PARTY-NOTICES
+
+This project includes third-party packages that are distributed under various open-source licenses. Below is a list of packages and their associated licenses.
+
+================================================================================
+Package: org.slf4j:jcl-over-slf4j
+Version: Not specified
+License: MIT License (Inferred from project’s official repository)
+Homepage: https://www.slf4j.org
+================================================================================
+
+================================================================================
+Package: org.apache.maven.plugins:maven-source-plugin
+Version: 3.3.1
+License: Apache License 2.0
+Homepage: https://maven.apache.org/plugins
+================================================================================
+
+================================================================================
+Package: io.mosip.kernel:kernel-core
+Version: 1.3.0-SNAPSHOT
+License: MPL-2.0 (Inferred from MOSIP official repository)
+Homepage: https://mosip.io
+================================================================================
+
+================================================================================
+Package: com.fasterxml.jackson.core:jackson-core
+Version: Not specified
+License: Apache License 2.0 (Inferred)
+Homepage: https://github.com/FasterXML/jackson-core
+================================================================================
+
+================================================================================
+Package: org.slf4j:jul-to-slf4j
+Version: Not specified
+License: MIT License (Inferred)
+Homepage: https://www.slf4j.org
+================================================================================
+
+================================================================================
+Package: org.apache.maven.plugins:maven-gpg-plugin
+Version: 3.2.3
+License: Apache License 2.0
+Homepage: https://maven.apache.org/plugins
+================================================================================
+
+================================================================================
+Package: pl.project13.maven:git-commit-id-plugin
+Version: 3.0.1
+License: Apache License 2.0
+Homepage: https://github.com/git-commit-id/git-commit-id-maven-plugin
+================================================================================
+
+================================================================================
+Package: org.apache.maven.plugins:maven-assembly-plugin
+Version: 3.1.1
+License: Apache License 2.0
+Homepage: https://maven.apache.org/plugins
+================================================================================
+
+================================================================================
+Package: io.mosip.kernel:kernel-bom
+Version: 1.3.0-SNAPSHOT
+License: MPL-2.0 (Inferred)
+Homepage: https://mosip.io
+================================================================================
+
+================================================================================
+Package: io.mosip.kernel:kernel-logger-logback
+Version: 1.3.0-SNAPSHOT
+License: MPL-2.0 (Inferred)
+Homepage: https://mosip.io
+================================================================================
+
+================================================================================
+Package: org.apache.maven.plugins:maven-compiler-plugin
+Version: 3.11.0
+License: Apache License 2.0
+Homepage: https://maven.apache.org/plugins
+================================================================================
+
+================================================================================
+Package: com.fasterxml.jackson.core:jackson-databind
+Version: Not specified
+License: Apache License 2.0 (Inferred)
+Homepage: https://github.com/FasterXML/jackson-databind
+================================================================================
+
+================================================================================
+Package: org.junit.vintage:junit-vintage-engine
+Version: Not specified
+License: EPL-1.0 (Inferred)
+Homepage: https://junit.org
+================================================================================
+
+================================================================================
+Package: org.apache.maven.plugins:maven-javadoc-plugin
+Version: 3.2.0
+License: Apache License 2.0
+Homepage: https://maven.apache.org/plugins
+================================================================================
+
+================================================================================
+Package: org.apache.maven.plugins:maven-surefire-plugin
+Version: 2.22.0
+License: Apache License 2.0
+Homepage: https://maven.apache.org/plugins
+================================================================================
+
+================================================================================
+Package: org.apache.maven.plugins:maven-jar-plugin
+Version: 3.0.2
+License: Apache License 2.0
+Homepage: https://maven.apache.org/plugins
+================================================================================
+
+================================================================================
+Package: org.apache.maven.plugins:maven-dependency-plugin
+Version: 3.1.2
+License: Apache License 2.0
+Homepage: https://maven.apache.org/plugins
+================================================================================
+
+================================================================================
+Package: io.mosip.kernel:kernel-bom
+Version: 1.3.0-beta.1
+License: MPL-2.0
+Homepage: https://mosip.io
+================================================================================
+
+================================================================================
+Package: io.mosip.kernel:kernel-core
+Version: 1.3.0-beta.1
+License: MPL-2.0
+Homepage: https://mosip.io
+================================================================================
+
+================================================================================
+Package: io.mosip.kernel:kernel-logger-logback
+Version: 1.3.0-beta.1
+License: MPL-2.0
+Homepage: https://mosip.io
+================================================================================
+
+================================================================================
+Package: io.mosip.imagedecoder:imagedecoder
+Version: 0.10.0-beta.1
+License: MPL-2.0
+Homepage: https://github.com/mosip
+================================================================================
+
+================================================================================
+Package: GitHub Actions Workflow – maven-build.yml
+Version: master-java21
+License: MIT License (Inferred)
+Homepage: https://github.com/mosip/kattu
+================================================================================
+
+================================================================================
+Package: GitHub Actions Workflow – maven-publish-to-nexus.yml
+Version: master-java21
+License: MIT License (Inferred)
+Homepage: https://github.com/mosip/kattu
+================================================================================
+
+Full license texts and additional details for each of the above packages are available in the license/ directory of this repository. Please refer to those files or the original source of each package for complete legal terms and conditions.

--- a/THIRD-PARTY-NOTICES.txt
+++ b/THIRD-PARTY-NOTICES.txt
@@ -47,7 +47,7 @@ Homepage: https://maven.apache.org/plugins
 ================================================================================
 Package: pl.project13.maven:git-commit-id-plugin
 Version: 3.0.1
-License: Apache License 2.0
+License: GNU Lesser General Public License v3.0 (LGPL-3.0)
 Homepage: https://github.com/git-commit-id/git-commit-id-maven-plugin
 ================================================================================
 
@@ -89,8 +89,8 @@ Homepage: https://github.com/FasterXML/jackson-databind
 ================================================================================
 Package: org.junit.vintage:junit-vintage-engine
 Version: Not specified
-License: EPL-1.0 (Inferred)
-Homepage: https://junit.org
+License: Eclipse Public License 2.0 (EPL-2.0)
+Homepage: https://junit.org/junit5/
 ================================================================================
 
 ================================================================================
@@ -147,20 +147,6 @@ Package: io.mosip.imagedecoder:imagedecoder
 Version: 0.10.0-beta.1
 License: MPL-2.0
 Homepage: https://github.com/mosip
-================================================================================
-
-================================================================================
-Package: GitHub Actions Workflow – maven-build.yml
-Version: master-java21
-License: MIT License (Inferred)
-Homepage: https://github.com/mosip/kattu
-================================================================================
-
-================================================================================
-Package: GitHub Actions Workflow – maven-publish-to-nexus.yml
-Version: master-java21
-License: MIT License (Inferred)
-Homepage: https://github.com/mosip/kattu
 ================================================================================
 
 Full license texts and additional details for each of the above packages are available in the license/ directory of this repository. Please refer to those files or the original source of each package for complete legal terms and conditions.


### PR DESCRIPTION
Removed several third-party package entries and their licenses from the THIRD-PARTY-NOTICES.txt file.