### PR TITLE
#1830 Changed to use latest version of dependent repo

### DIFF
--- a/imagedecoder/pom.xml
+++ b/imagedecoder/pom.xml
@@ -40,9 +40,9 @@
 		<git.commit.id.plugin.version>3.0.1</git.commit.id.plugin.version>
 
 		<!-- Mosip kernel -->
-		<kernel.bom.version>1.4.0-SNAPSHOT</kernel.bom.version>
-		<kernel.core.version>1.4.0-SNAPSHOT</kernel.core.version>
-		<kernel.logger.logback.version>1.4.0-SNAPSHOT</kernel.logger.logback.version>
+		<kernel.bom.version>1.3.1-rc.1</kernel.bom.version>
+		<kernel.core.version>1.3.1-rc.1</kernel.core.version>
+		<kernel.logger.logback.version>1.3.1-rc.1</kernel.logger.logback.version>
 	</properties>
 
 	<dependencyManagement>

--- a/sample/pom.xml
+++ b/sample/pom.xml
@@ -39,9 +39,9 @@
 		<git.commit.id.plugin.version>3.0.1</git.commit.id.plugin.version>
 
 		<!-- Mosip kernel -->
-		<kernel.bom.version>1.4.0-SNAPSHOT</kernel.bom.version>
-		<kernel.core.version>1.4.0-SNAPSHOT</kernel.core.version>
-		<kernel.logger.logback.version>1.4.0-SNAPSHOT</kernel.logger.logback.version>
+		<kernel.bom.version>1.3.1-rc.1</kernel.bom.version>
+		<kernel.core.version>1.3.1-rc.1</kernel.core.version>
+		<kernel.logger.logback.version>1.3.1-rc.1</kernel.logger.logback.version>
 		<mosip.imagedecoder.version>0.10.0-SNAPSHOT</mosip.imagedecoder.version>
 	</properties>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Mosip kernel dependency versions from 1.4.0-SNAPSHOT to 1.3.1-rc.1 across build configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->